### PR TITLE
Implemented sync functionality with aggregation and batching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,5 @@
-# API Endpoint Configuration
-# This is where your activity data will be sent every 30 minutes
-API_ENDPOINT=https://your-api.com/api/activities
+# Authentication API URL
+AUTH_API_URL=https://trackoptimizer.app
+API_ENDPOINT=https://trackoptimizer.app/api/activities
 
-# Optional: API Key for authentication
-# If your API requires authentication, uncomment and set this
-# API_KEY=your-api-key-here
+GEMINI_API_KEY=

--- a/main.js
+++ b/main.js
@@ -135,7 +135,7 @@ async function startTracking() {
 
   // Initialize network sync (every 30 minutes)
   if (process.env.API_ENDPOINT) {
-    networkSync = new NetworkSync(tracker);
+    networkSync = new NetworkSync(tracker, authManager);
     networkSync.startSync();
     console.log('✅ Network sync enabled (every 30 minutes)');
   } else {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "electron .",
     "view-data": "node view-data.js",
+    "preview:sessions": "electron scripts/preview-sessions.js",
     "package:mac": "electron-builder --mac",
     "package:win": "electron-builder --win",
     "package:linux": "electron-builder --linux",

--- a/scripts/preview-sessions.js
+++ b/scripts/preview-sessions.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+// Preview aggregated activity sessions from the local SQLite database.
+// This script reuses the same aggregation logic used by the sync engine
+// so you can inspect how raw samples get merged into sessions.
+
+const path = require('path');
+const ActivityTracker = require('../src/tracker');
+const { aggregateActivitiesToSessions } = require('../src/sessionAggregator');
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+
+async function main() {
+  console.log('🔍 Previewing aggregated sessions from activity.db...');
+
+  const tracker = new ActivityTracker();
+  tracker.initialize();
+
+  // By default, only look at unsynced activities
+  const unsynced = tracker.getUnsyncedActivities();
+
+  console.log(`Found ${unsynced.length} unsynced raw records`);
+
+  const { sessions, sourceIds } = aggregateActivitiesToSessions(unsynced);
+
+  console.log(`Aggregated into ${sessions.length} sessions (covering ${sourceIds.length} raw records)\n`);
+
+  // Pretty-print a concise view of each session
+  sessions.forEach((session, index) => {
+    const line = [
+      `#${index + 1}`,
+      `[${session.startTimestamp} → ${session.endTimestamp}]`,
+      `(${session.durationSeconds}s, ${session.sample_count} samples)`,
+      session.process_name || 'Unknown process',
+      session.window_title || '',
+      session.browser_url ? `URL: ${session.browser_url}` : '',
+      `CPU avg: ${session.cpu_usage_avg != null ? session.cpu_usage_avg.toFixed(2) + '%' : 'n/a'}`,
+      `Mem avg: ${session.memory_usage_avg != null ? session.memory_usage_avg.toFixed(2) + '%' : 'n/a'}`,
+      `Input: ${session.input_events_total}`,
+      session.is_user_active ? 'active' : 'idle'
+    ].filter(Boolean).join(' | ');
+
+    console.log(line);
+  });
+
+  // Also output raw JSON if needed (uncomment to use)
+  // console.log(JSON.stringify({ sessions, sourceIds }, null, 2));
+
+  tracker.stop();
+}
+
+main().catch((err) => {
+  console.error('❌ Error while previewing sessions:', err);
+  process.exit(1);
+});

--- a/src/networkSync.js
+++ b/src/networkSync.js
@@ -13,10 +13,10 @@ class NetworkSync {
 
   startSync() {
     console.log('🔄 Network sync initialized (every 30 minutes)');
-    
+
     // Sync immediately on start if there's unsynced data
     setTimeout(() => this.syncNow(), 5000); // Wait 5 seconds after startup
-    
+
     // Then sync every 30 minutes
     this.syncInterval = setInterval(() => {
       this.syncNow();
@@ -34,21 +34,28 @@ class NetworkSync {
   async syncNow() {
     try {
       const unsyncedData = this.tracker.getUnsyncedActivities();
-      
+
       if (unsyncedData.length === 0) {
         console.log('✅ No data to sync');
         return { success: true, synced: 0 };
       }
 
       // Aggregate raw samples into higher-level sessions
-      const { sessions, sourceIds } = aggregateActivitiesToSessions(unsyncedData);
+      const { sessions, sourceIds } =
+        aggregateActivitiesToSessions(unsyncedData);
 
       if (sessions.length === 0) {
         console.log('⚠️ Aggregation produced no sessions; skipping sync');
-        return { success: false, synced: 0, error: 'No sessions after aggregation' };
+        return {
+          success: false,
+          synced: 0,
+          error: 'No sessions after aggregation',
+        };
       }
 
-      console.log(`📤 Syncing ${sessions.length} aggregated sessions from ${unsyncedData.length} raw records...`);
+      console.log(
+        `📤 Syncing ${sessions.length} aggregated sessions from ${unsyncedData.length} raw records...`
+      );
 
       // Batch syncing to avoid timeouts with large datasets
       const batchSize = 100; // 100 sessions per batch
@@ -59,7 +66,7 @@ class NetworkSync {
 
       // Optional: include authenticated user ID if authManager is provided
       let userId = null;
-      let authCookie = null;
+      let authHeadersConfig = {};
 
       if (this.authManager) {
         const user = this.authManager.getUser?.();
@@ -67,13 +74,12 @@ class NetworkSync {
           userId = user.id;
         }
 
-        const authHeadersConfig = this.authManager.getAuthHeaders?.() || {};
-        authCookie = authHeadersConfig.headers?.Cookie;
+        authHeadersConfig = this.authManager.getAuthHeaders?.() || {};
       }
 
       const payload = {
         userId,
-        activities: sessions.map(session => ({
+        activities: sessions.map((session) => ({
           // Time and duration
           timestamp: session.startTimestamp,
           start_timestamp: session.startTimestamp,
@@ -96,53 +102,58 @@ class NetworkSync {
           is_user_active: session.is_user_active,
 
           // Debug/analytics fields (optional on server)
-          sample_count: session.sample_count
+          sample_count: session.sample_count,
         })),
         metadata: {
           total_records: unsyncedData.length,
           total_sessions: sessions.length,
           sync_timestamp: new Date().toISOString(),
-          device_platform: process.platform
-        }
+          device_platform: process.platform,
+        },
       };
 
       // Send to API endpoint
       const headers = {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...(authHeadersConfig.headers || {}),
       };
 
-      // Include Better Auth cookie if available
-      if (authCookie) {
-        headers['Cookie'] = authCookie;
-      }
-
-      // Add API key if configured
+      // Add API key if configured (overrides any Authorization from auth headers)
       if (this.apiKey) {
         headers['Authorization'] = `Bearer ${this.apiKey}`;
       }
 
       const response = await axios.post(this.apiEndpoint, payload, {
         headers,
-        timeout: 30000 // 30 second timeout
+        timeout: 30000, // 30 second timeout
       });
 
       if (response.status >= 200 && response.status < 300) {
-        console.log(`✅ Server accepted ${sessions.length} sessions (${sourceIds.length} raw records)`);
-        console.log(`🔍 sourceIds to mark as synced:`, sourceIds.slice(0, 10), sourceIds.length > 10 ? `... and ${sourceIds.length - 10} more` : '');
-        
+        console.log(
+          `✅ Server accepted ${sessions.length} sessions (${sourceIds.length} raw records)`
+        );
+        console.log(
+          `🔍 sourceIds to mark as synced:`,
+          sourceIds.slice(0, 10),
+          sourceIds.length > 10 ? `... and ${sourceIds.length - 10} more` : ''
+        );
+
         // Mark all underlying raw records as synced in local database
         this.tracker.markAsSynced(sourceIds);
-        
+
         console.log(`✅ Successfully completed sync`);
-        return { success: true, synced: sessions.length, rawSynced: sourceIds.length };
+        return {
+          success: true,
+          synced: sessions.length,
+          rawSynced: sourceIds.length,
+        };
       } else {
         console.error(`❌ Sync failed with status: ${response.status}`);
         return { success: false, error: `HTTP ${response.status}` };
       }
-
     } catch (error) {
       console.error('❌ Network sync error:', error.message);
-      
+
       // Log more details for debugging
       if (error.response) {
         console.error('Response status:', error.response.status);
@@ -150,7 +161,7 @@ class NetworkSync {
       } else if (error.request) {
         console.error('No response received from server');
       }
-      
+
       return { success: false, error: error.message };
     }
   }
@@ -158,27 +169,29 @@ class NetworkSync {
   async syncInBatches(sessions, sourceIds, batchSize) {
     let totalSynced = 0;
     let totalRawSynced = 0;
-    
+
     // Create a map of session index to source IDs
     const sessionSourceMap = new Map();
     sessions.forEach((session, idx) => {
       sessionSourceMap.set(idx, session.source_ids || []);
     });
-    
+
     for (let i = 0; i < sessions.length; i += batchSize) {
       const batch = sessions.slice(i, i + batchSize);
       const batchNum = Math.floor(i / batchSize) + 1;
       const totalBatches = Math.ceil(sessions.length / batchSize);
-      
+
       // Collect source IDs for this batch
       const batchSourceIds = [];
       for (let j = i; j < i + batch.length; j++) {
         const sessionSources = sessionSourceMap.get(j) || [];
         batchSourceIds.push(...sessionSources);
       }
-      
-      console.log(`📦 Syncing batch ${batchNum}/${totalBatches} (${batch.length} sessions, ${batchSourceIds.length} raw records)...`);
-      
+
+      console.log(
+        `📦 Syncing batch ${batchNum}/${totalBatches} (${batch.length} sessions, ${batchSourceIds.length} raw records)...`
+      );
+
       try {
         const result = await this.syncBatch(batch, batchSourceIds);
         if (result.success) {
@@ -192,20 +205,22 @@ class NetworkSync {
         console.error(`❌ Batch ${batchNum} error:`, error.message);
         // Continue with next batch
       }
-      
+
       // Small delay between batches to avoid overwhelming the server
       if (i + batchSize < sessions.length) {
-        await new Promise(resolve => setTimeout(resolve, 1000)); // 1 second delay
+        await new Promise((resolve) => setTimeout(resolve, 1000)); // 1 second delay
       }
     }
-    
-    console.log(`✅ Batch sync complete: ${totalSynced} sessions (${totalRawSynced} raw records)`);
+
+    console.log(
+      `✅ Batch sync complete: ${totalSynced} sessions (${totalRawSynced} raw records)`
+    );
     return { success: true, synced: totalSynced, rawSynced: totalRawSynced };
   }
 
   async syncBatch(sessions, batchSourceIds) {
     let userId = null;
-    let authCookie = null;
+    let authHeadersConfig = {};
 
     if (this.authManager) {
       const user = this.authManager.getUser?.();
@@ -213,13 +228,12 @@ class NetworkSync {
         userId = user.id;
       }
 
-      const authHeadersConfig = this.authManager.getAuthHeaders?.() || {};
-      authCookie = authHeadersConfig.headers?.Cookie;
+      authHeadersConfig = this.authManager.getAuthHeaders?.() || {};
     }
 
     const payload = {
       userId,
-      activities: sessions.map(session => ({
+      activities: sessions.map((session) => ({
         timestamp: session.startTimestamp,
         start_timestamp: session.startTimestamp,
         end_timestamp: session.endTimestamp,
@@ -235,42 +249,52 @@ class NetworkSync {
         mouse_movements: session.mouse_movements_total,
         input_events: session.input_events_total,
         is_user_active: session.is_user_active,
-        sample_count: session.sample_count
+        sample_count: session.sample_count,
       })),
       metadata: {
         total_records: batchSourceIds.length,
         total_sessions: sessions.length,
         sync_timestamp: new Date().toISOString(),
-        device_platform: process.platform
-      }
+        device_platform: process.platform,
+      },
     };
 
     const headers = {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...(authHeadersConfig.headers || {}),
     };
 
-    if (authCookie) {
-      headers['Cookie'] = authCookie;
-    }
-
+    // Add API key if configured (overrides any Authorization from auth headers)
     if (this.apiKey) {
       headers['Authorization'] = `Bearer ${this.apiKey}`;
     }
 
     const response = await axios.post(this.apiEndpoint, payload, {
       headers,
-      timeout: 30000
+      timeout: 30000,
     });
 
     if (response.status >= 200 && response.status < 300) {
-      console.log(`✅ Server accepted ${sessions.length} sessions (${batchSourceIds.length} raw records)`);
-      console.log(`🔍 sourceIds to mark as synced:`, batchSourceIds.slice(0, 10), batchSourceIds.length > 10 ? `... and ${batchSourceIds.length - 10} more` : '');
-      
+      console.log(
+        `✅ Server accepted ${sessions.length} sessions (${batchSourceIds.length} raw records)`
+      );
+      console.log(
+        `🔍 sourceIds to mark as synced:`,
+        batchSourceIds.slice(0, 10),
+        batchSourceIds.length > 10
+          ? `... and ${batchSourceIds.length - 10} more`
+          : ''
+      );
+
       // Mark all underlying raw records as synced in local database
       this.tracker.markAsSynced(batchSourceIds);
-      
+
       console.log(`✅ Successfully completed sync`);
-      return { success: true, synced: sessions.length, rawSynced: batchSourceIds.length };
+      return {
+        success: true,
+        synced: sessions.length,
+        rawSynced: batchSourceIds.length,
+      };
     } else {
       console.error(`❌ Sync failed with status: ${response.status}`);
       return { success: false, error: `HTTP ${response.status}` };

--- a/src/networkSync.js
+++ b/src/networkSync.js
@@ -1,8 +1,10 @@
 const axios = require('axios');
+const { aggregateActivitiesToSessions } = require('./sessionAggregator');
 
 class NetworkSync {
-  constructor(tracker) {
+  constructor(tracker, authManager = null) {
     this.tracker = tracker;
+    this.authManager = authManager;
     this.syncInterval = null;
     this.syncIntervalMs = 30 * 60 * 1000; // 30 minutes
     this.apiEndpoint = process.env.API_ENDPOINT;
@@ -38,29 +40,60 @@ class NetworkSync {
         return { success: true, synced: 0 };
       }
 
-      console.log(`📤 Syncing ${unsyncedData.length} records...`);
+      // Aggregate raw samples into higher-level sessions
+      const { sessions, sourceIds } = aggregateActivitiesToSessions(unsyncedData);
 
-      // Prepare payload
+      if (sessions.length === 0) {
+        console.log('⚠️ Aggregation produced no sessions; skipping sync');
+        return { success: false, synced: 0, error: 'No sessions after aggregation' };
+      }
+
+      console.log(`📤 Syncing ${sessions.length} aggregated sessions from ${unsyncedData.length} raw records...`);
+
+      // Optional: include authenticated user ID if authManager is provided
+      let userId = null;
+      let authCookie = null;
+
+      if (this.authManager) {
+        const user = this.authManager.getUser?.();
+        if (user && user.id) {
+          userId = user.id;
+        }
+
+        const authHeadersConfig = this.authManager.getAuthHeaders?.() || {};
+        authCookie = authHeadersConfig.headers?.Cookie;
+      }
+
       const payload = {
-        activities: unsyncedData.map(record => ({
-          id: record.id,
-          timestamp: record.timestamp,
-          window_title: record.window_title,
-          process_name: record.process_name,
-          process_path: record.process_path,
-          cpu_usage: parseFloat(record.cpu_usage),
-          memory_usage: parseFloat(record.memory_usage),
-          platform: record.platform,
-          browser_url: record.browser_url,
-          browser_tab_title: record.browser_tab_title,
-          mouse_movements: record.mouse_movements || 0,
-          input_events: record.input_events || record.mouse_movements || 0,
-          is_user_active: record.is_user_active === 1,
-          created_at: record.created_at,
-          updated_at: record.updated_at || record.created_at
+        userId,
+        activities: sessions.map(session => ({
+          // Time and duration
+          timestamp: session.startTimestamp,
+          start_timestamp: session.startTimestamp,
+          end_timestamp: session.endTimestamp,
+          duration_seconds: session.durationSeconds,
+
+          // App/window/browser data
+          window_title: session.window_title,
+          process_name: session.process_name,
+          process_path: session.process_path,
+          platform: session.platform,
+          browser_url: session.browser_url,
+          browser_tab_title: session.browser_tab_title,
+
+          // Aggregated metrics
+          cpu_usage: session.cpu_usage_avg,
+          memory_usage: session.memory_usage_avg,
+          mouse_movements: session.mouse_movements_total,
+          input_events: session.input_events_total,
+          is_user_active: session.is_user_active,
+
+          // Debug/analytics fields (optional on server)
+          sample_count: session.sample_count
         })),
         metadata: {
           total_records: unsyncedData.length,
+          total_sessions: sessions.length,
           sync_timestamp: new Date().toISOString(),
           device_platform: process.platform
         }
@@ -70,6 +103,11 @@ class NetworkSync {
       const headers = {
         'Content-Type': 'application/json'
       };
+
+      // Include Better Auth cookie if available
+      if (authCookie) {
+        headers['Cookie'] = authCookie;
+      }
 
       // Add API key if configured
       if (this.apiKey) {
@@ -82,12 +120,11 @@ class NetworkSync {
       });
 
       if (response.status >= 200 && response.status < 300) {
-        // Mark as synced in local database
-        const ids = unsyncedData.map(r => r.id);
-        this.tracker.markAsSynced(ids);
+        // Mark all underlying raw records as synced in local database
+        this.tracker.markAsSynced(sourceIds);
         
-        console.log(`✅ Successfully synced ${unsyncedData.length} records`);
-        return { success: true, synced: unsyncedData.length };
+        console.log(`✅ Successfully synced ${sessions.length} sessions (${sourceIds.length} raw records)`);
+        return { success: true, synced: sessions.length, rawSynced: sourceIds.length };
       } else {
         console.error(`❌ Sync failed with status: ${response.status}`);
         return { success: false, error: `HTTP ${response.status}` };

--- a/src/sessionAggregator.js
+++ b/src/sessionAggregator.js
@@ -1,0 +1,236 @@
+// Session aggregation for activity records
+// Groups consecutive samples for the same app/window/URL into sessions.
+
+/**
+ * Convert a SQLite row timestamp into a Date.
+ * Falls back across updated_at -> created_at -> timestamp.
+ */
+function getRecordTimes(record) {
+  const created = record.created_at || record.timestamp;
+  const updated = record.updated_at || created;
+
+  const createdAt = created ? new Date(created) : null;
+  const updatedAt = updated ? new Date(updated) : createdAt;
+
+  return { createdAt, updatedAt };
+}
+
+/**
+ * Build a grouping key for a record.
+ * Keep it simple and deterministic so sessions represent
+ * contiguous periods on the same window/tab/process.
+ */
+function buildKey(record) {
+  return [
+    record.process_name || '',
+    record.window_title || '',
+    record.browser_url || '',
+    record.platform || '',
+    record.process_path || ''
+  ].join('|');
+}
+
+/**
+ * Aggregate raw activity records into higher-level sessions.
+ *
+ * @param {Array<Object>} records Raw activity rows from SQLite
+ * @param {Object} [options]
+ * @param {number} [options.maxGapMs] Maximum allowed gap between samples in the same session
+ * @returns {{ sessions: Array<Object>, sourceIds: Array<number> }}
+ */
+function aggregateActivitiesToSessions(records, options = {}) {
+  const maxGapMs = options.maxGapMs ?? 15000; // 15 seconds by default
+
+  if (!Array.isArray(records) || records.length === 0) {
+    return { sessions: [], sourceIds: [] };
+  }
+
+  // Sort by time ascending to build contiguous sessions
+  const sorted = [...records].sort((a, b) => {
+    const aTimes = getRecordTimes(a);
+    const bTimes = getRecordTimes(b);
+
+    const aTime = aTimes.createdAt ? aTimes.createdAt.getTime() : 0;
+    const bTime = bTimes.createdAt ? bTimes.createdAt.getTime() : 0;
+
+    return aTime - bTime;
+  });
+
+  const sessions = [];
+  const allSourceIds = new Set();
+
+  let current = null;
+
+  const flushCurrent = () => {
+    if (!current) return;
+
+    const durationMs = current.endTime && current.startTime
+      ? current.endTime.getTime() - current.startTime.getTime()
+      : 0;
+    const durationSeconds = Math.max(1, Math.round(durationMs / 1000));
+
+    const cpuAvg = current.cpuCount > 0 ? current.cpuSum / current.cpuCount : null;
+    const memAvg = current.memCount > 0 ? current.memSum / current.memCount : null;
+
+    sessions.push({
+      startTimestamp: current.startTime.toISOString(),
+      endTimestamp: current.endTime.toISOString(),
+      durationSeconds,
+
+      window_title: current.windowTitle,
+      process_name: current.processName,
+      process_path: current.processPath,
+      platform: current.platform,
+      browser_url: current.browserUrl,
+      browser_tab_title: current.browserTabTitle,
+
+      cpu_usage_avg: cpuAvg,
+      memory_usage_avg: memAvg,
+
+      mouse_movements_total: current.mouseMovementsTotal,
+      input_events_total: current.inputEventsTotal,
+      is_user_active: current.isUserActive,
+
+      sample_count: current.sampleCount,
+      source_ids: Array.from(current.sourceIds)
+    });
+
+    current = null;
+  };
+
+  for (const record of sorted) {
+    const { createdAt, updatedAt } = getRecordTimes(record);
+    if (!createdAt) {
+      // Skip records with no usable timestamp
+      continue;
+    }
+
+    const key = buildKey(record);
+    const timestampMs = createdAt.getTime();
+
+    const cpu = record.cpu_usage != null ? parseFloat(record.cpu_usage) : NaN;
+    const mem = record.memory_usage != null ? parseFloat(record.memory_usage) : NaN;
+
+    const mouseMovements = typeof record.mouse_movements === 'number'
+      ? record.mouse_movements
+      : (record.mouse_movements ? Number(record.mouse_movements) : 0);
+
+    const inputEventsRaw = (typeof record.input_events === 'number'
+      ? record.input_events
+      : (record.input_events ? Number(record.input_events) : NaN));
+
+    const inputEvents = Number.isNaN(inputEventsRaw) ? mouseMovements : inputEventsRaw;
+
+    const isActive = record.is_user_active === 1 || record.is_user_active === true;
+
+    if (!current) {
+      // Start first session
+      current = {
+        key,
+        startTime: createdAt,
+        endTime: updatedAt || createdAt,
+
+        windowTitle: record.window_title || '',
+        processName: record.process_name || '',
+        processPath: record.process_path || '',
+        platform: record.platform || '',
+        browserUrl: record.browser_url || '',
+        browserTabTitle: record.browser_tab_title || '',
+
+        cpuSum: Number.isNaN(cpu) ? 0 : cpu,
+        cpuCount: Number.isNaN(cpu) ? 0 : 1,
+        memSum: Number.isNaN(mem) ? 0 : mem,
+        memCount: Number.isNaN(mem) ? 0 : 1,
+
+        mouseMovementsTotal: mouseMovements,
+        inputEventsTotal: inputEvents,
+        isUserActive: isActive,
+
+        sampleCount: 1,
+        sourceIds: new Set(record.id != null ? [record.id] : [])
+      };
+
+      if (record.id != null) {
+        allSourceIds.add(record.id);
+      }
+      continue;
+    }
+
+    const timeGap = timestampMs - current.endTime.getTime();
+
+    const sameKey = key === current.key;
+    const withinGap = timeGap >= 0 && timeGap <= maxGapMs;
+
+    if (sameKey && withinGap) {
+      // Extend current session
+      if (updatedAt && updatedAt > current.endTime) {
+        current.endTime = updatedAt;
+      } else if (createdAt > current.endTime) {
+        current.endTime = createdAt;
+      }
+
+      if (!Number.isNaN(cpu)) {
+        current.cpuSum += cpu;
+        current.cpuCount += 1;
+      }
+      if (!Number.isNaN(mem)) {
+        current.memSum += mem;
+        current.memCount += 1;
+      }
+
+      current.mouseMovementsTotal += mouseMovements;
+      current.inputEventsTotal += inputEvents;
+      current.isUserActive = current.isUserActive || isActive;
+      current.sampleCount += 1;
+
+      if (record.id != null) {
+        current.sourceIds.add(record.id);
+        allSourceIds.add(record.id);
+      }
+    } else {
+      // Flush current session and start a new one
+      flushCurrent();
+
+      current = {
+        key,
+        startTime: createdAt,
+        endTime: updatedAt || createdAt,
+
+        windowTitle: record.window_title || '',
+        processName: record.process_name || '',
+        processPath: record.process_path || '',
+        platform: record.platform || '',
+        browserUrl: record.browser_url || '',
+        browserTabTitle: record.browser_tab_title || '',
+
+        cpuSum: Number.isNaN(cpu) ? 0 : cpu,
+        cpuCount: Number.isNaN(cpu) ? 0 : 1,
+        memSum: Number.isNaN(mem) ? 0 : mem,
+        memCount: Number.isNaN(mem) ? 0 : 1,
+
+        mouseMovementsTotal: mouseMovements,
+        inputEventsTotal: inputEvents,
+        isUserActive: isActive,
+
+        sampleCount: 1,
+        sourceIds: new Set(record.id != null ? [record.id] : [])
+      };
+
+      if (record.id != null) {
+        allSourceIds.add(record.id);
+      }
+    }
+  }
+
+  // Flush final session
+  flushCurrent();
+
+  return {
+    sessions,
+    sourceIds: Array.from(allSourceIds)
+  };
+}
+
+module.exports = {
+  aggregateActivitiesToSessions
+};

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -215,13 +215,26 @@ class ActivityTracker {
   }
 
   markAsSynced(ids) {
-    if (!ids || ids.length === 0) return;
+    if (!ids || ids.length === 0) {
+      console.log('⚠️ markAsSynced called with empty or null ids');
+      return;
+    }
     
-    const placeholders = ids.map(() => '?').join(',');
-    const stmt = this.db.prepare(`UPDATE activities SET synced = 1 WHERE id IN (${placeholders})`);
-    stmt.run(...ids);
-    
-    console.log(`✅ Marked ${ids.length} records as synced`);
+    try {
+      const placeholders = ids.map(() => '?').join(',');
+      const stmt = this.db.prepare(`UPDATE activities SET synced = 1 WHERE id IN (${placeholders})`);
+      const result = stmt.run(...ids);
+      
+      console.log(`✅ Marked ${ids.length} records as synced (${result.changes} rows affected)`);
+      
+      // Verify the update
+      const verifyStmt = this.db.prepare(`SELECT COUNT(*) as count FROM activities WHERE synced = 1 AND id IN (${placeholders})`);
+      const verified = verifyStmt.get(...ids);
+      console.log(`🔍 Verification: ${verified.count}/${ids.length} records confirmed as synced`);
+    } catch (error) {
+      console.error('❌ Error in markAsSynced:', error.message);
+      throw error;
+    }
   }
 
   getDatabase() {


### PR DESCRIPTION
























































































## Summary
1. **Add authenticated startup flow before tracking begins** – [main.js](cci:7://file:///Volumes/Dati/coding/projects/electron-activity-tracker/main.js:0:0-0:0) now builds an `AuthManager`, validates the Better Auth session, shows a login window when needed, and only boots the tracker + tray UI once the user is verified. Manual sync, logout, and quit options in the tray menu were updated to respect this flow and expose unsynced counts/user info (@main.js#39-225).
2. **Introduce batched network syncing to the TrackOptimizer API** – [src/networkSync.js](cci:7://file:///Volumes/Dati/coding/projects/electron-activity-tracker/src/networkSync.js:0:0-0:0) aggregates unsynced SQLite rows into higher-level sessions, attaches Better Auth cookies or API keys, chunks uploads into batches of 100, and marks raw records as synced after successful POSTs (@src/networkSync.js#4-279). [.env.example](cci:7://file:///Volumes/Dati/coding/projects/electron-activity-tracker/.env.example:0:0-0:0) documents the required `AUTH_API_URL` and `API_ENDPOINT` variables (@.env.example#1-5).
3. **Aggregate raw samples into sessions before syncing** – `src/sessionAggregator.js` groups contiguous activity rows by window/process, computes duration and averages, and carries source IDs so [NetworkSync](cci:2://file:///Volumes/Dati/coding/projects/electron-activity-tracker/src/networkSync.js:3:0-278:1) can reconcile what was uploaded (@src/sessionAggregator.js#1-100).
4. **Enhance local tracking fidelity** – [src/inputTracker.js](cci:7://file:///Volumes/Dati/coding/projects/electron-activity-tracker/src/inputTracker.js:0:0-0:0) provides macOS idle-based activity stats that are injected into [ActivityTracker](cci:2://file:///Volumes/Dati/coding/projects/electron-activity-tracker/src/tracker.js:8:0-242:1), while [src/tracker.js](cci:7://file:///Volumes/Dati/coding/projects/electron-activity-tracker/src/tracker.js:0:0-0:0) records those stats, deduplicates `loginwindow` noise, exposes DB stats, and marks records as synced after uploads (@src/inputTracker.js#1-87, @src/tracker.js#1-246).

## Motivation
These changes implement “Spec 004 – Sync to Web App” by ensuring only authenticated users can run the background tracker and by pushing their locally captured activity to the TrackOptimizer backend reliably. Session aggregation keeps payloads meaningful, while batching and synced-record bookkeeping make the client resilient to large datasets.

## Testing
- [ ] `npm start`
- [ ] Manual login via the Electron auth window
- [ ] Trigger “Sync Now” from the tray and confirm records are marked synced afterward